### PR TITLE
rename bootstrapTest to bootstrap_test

### DIFF
--- a/thedmstoolkit/urls.py
+++ b/thedmstoolkit/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     # login
     path("", TestHome.as_view(), name="test_home"),
     # test sites
-    path("bootstrapTest/", BootstrapTest.as_view(), name="bootstrap_test"),
+    path("bootstrap_test/", BootstrapTest.as_view(), name="bootstrap_test"),
     # static files
     *static(settings.STATIC_URL, document_root=settings.STATIC_ROOT),
 ]


### PR DESCRIPTION
#Fix site path name to follow convention

Path name should follow snake_case naming convention