### PR TITLE
add the ToolkitConfig app to the INSTALLED_APPS list

### DIFF
--- a/thedmstoolkit/settings.py
+++ b/thedmstoolkit/settings.py
@@ -37,8 +37,8 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",
+    "toolkit.apps.ToolkitConfig",
 ]
-
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
# Add ToolkitConfig to INSTALLED_APPS

Models were not able to be automatically attributed to an app because the app they are in, `toolkit` was not listed in the `INSTALLED_APPS` list

Master will need to be merged into all open branches