### PR TITLE
Ignore auto generated migration files

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,6 @@ plugins = mypy_django_plugin.main
 
 [mypy.plugins.django-stubs]
 django_settings_module = "thedmstoolkit.settings"
+
+[mypy-toolkit.migrations.*]
+ignore_errors = True


### PR DESCRIPTION
#Fix mypy errors

Mypy is throwing errors when analyzing migrations files. This is supposed to be turned off with `[mypy-*.migrations.*] ignore_errors = True` in `mypy_django.ini`, but it does not seam to work.

Currently, this is blocking any progress on branches using the database, specifically #53


# Changes

* Added an ignore glob pattern for all migration files to `mypy.ini`
