### PR TITLE
Remove break from base

### DIFF
--- a/toolkit/templates/base.html
+++ b/toolkit/templates/base.html
@@ -19,7 +19,6 @@
   </head>
   <body>
     <div id="content" class="box">
-      <br/>
 
       {% block content %}
       {% endblock content %}


### PR DESCRIPTION
# Remove break from base.html

A `<br/>` tag was adding extra space at the top of pages that extend base

# Changes
* Removed `<br/>` tag
