### PR TITLE
Update deepsource to ignore migrations folder

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,15 +1,14 @@
 version = 1
-exclude_patterns = ["toolkit/migrations/**"]
+
 test_patterns = ["tests/**", "test_*.py"]
+
+exclude_patterns = ["toolkit/migrations/**"]
 
 [[analyzers]]
 name = "python"
 enabled = true
-dependency_file_paths = ["requirements/prod.txt"]
 
 [analyzers.meta]
-skip_doc_coverage = ["toolkit/migrations"]
-type_checker = "mypy"
 runtime_version = "3.x.x"
 
 [[transformers]]

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -10,9 +10,9 @@ dependency_file_paths = ["requirements/prod.txt"]
 [analyzers.meta]
 skip_doc_coverage = ["toolkit/migrations"]
 type_checker = "mypy"
+runtime_version = "3.x.x"
 
 [[transformers]]
-runtime_version = "3.x.x"
 name = "black"
 enabled = true
 

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,13 +1,18 @@
 version = 1
+exclude_patterns = ["toolkit/migrations/**"]
+test_patterns = ["tests/**", "test_*.py"]
 
 [[analyzers]]
 name = "python"
 enabled = true
+dependency_file_paths = ["requirements/prod.txt"]
 
-  [analyzers.meta]
-  runtime_version = "3.x.x"
+[analyzers.meta]
+skip_doc_coverage = ["toolkit/migrations"]
+type_checker = "mypy"
 
 [[transformers]]
+runtime_version = "3.x.x"
 name = "black"
 enabled = true
 


### PR DESCRIPTION
# Update Deepsource to ignore migrations and to run mypy instead of the mypy workflow 

Every time migrations are made I have to ignore them manually, so I'm adding the migrations folder to a list of ignored folders

At the same time I found out that deepsource can handle running mypy which is our type checker, so I am removing `mypy.yml` and activating mypy in deepsource

## Link to github card

# Changes

* Added migrations to exclude patterns
* Add requirements/prod.txt as a requirements file
* Set type checker to mypy
* Added default test patterns

