### PR TITLE
Fixes to login and create_user

### DIFF
--- a/toolkit/views/create_account.py
+++ b/toolkit/views/create_account.py
@@ -95,6 +95,7 @@ def create_user(username: str, email: str, password: str) -> Optional[User]:
     except User.DoesNotExist:
         pass
 
-    a = User(email=email, username=username, password=password)
+    a = User(email=email, username=username)
+    a.set_password(password)
     a.save()
     return a

--- a/toolkit/views/login.py
+++ b/toolkit/views/login.py
@@ -16,7 +16,7 @@ class Login(View):
         context = {"username": username}
         return render(request, "login.html", context)
 
-    def post(self, request):
+    def post(self, request, **kwargs):
         """POST method for login page."""
         username = request.POST.get("username")
         password = request.POST.get("password")


### PR DESCRIPTION
# Hotfix for Login Issues

Login previously was breaking when creating a new user and being redirected to login page as the POST method did not have the **kwargs argument, so when the username field was passed in as an argument, an error occurred. 

Also, when trying to authenticate a user, the authenticate method would return None, despite giving the correct credentials, so a user couldn't login. The issue was in the create_user function in create_account.py where the password was being passed in directly to the User arguments such that:

User(email=email, username=username, password=password)

Django doesn't like when passwords are stored directly because I believe it doesn't hash the password, so you are saving the plaintext. This creates the problem in authenticate() as it thinks the plaintext password is a hash, when in reality it isn't.

## Link to github card
#112 

# Changes

* When creating user in function, used set_password() function instead of passing it directly
* Added **kwargs argument to post method


You may also wish to include links to related pull requests, issues, or branches which may affect your changes.
