### PR TITLE
Loot generation frontend backend enhancements

### DIFF
--- a/toolkit/models.py
+++ b/toolkit/models.py
@@ -72,6 +72,7 @@ class Armor(models.Model):
     def __str__(self):
         return "Armor"
 
+
 class Weapon(models.Model):
     """
     The Model for weapons used to store weapons to pull from when generating loot
@@ -98,7 +99,7 @@ class Weapon(models.Model):
     Special_Characteristics = models.IntegerField()
     # store as a binary where Heavy Light TwoHanded Reach Versatile Finesse Throwable Ammunition Special
     # So heavy two handed with reach would be 101100000
-    
+
     def __str__(self):
         return "Weapon"
 
@@ -118,7 +119,7 @@ class GenericItem(models.Model):
     Name = models.CharField(primary_key=True, max_length=30)
     Description = models.CharField(max_length=255)
     Base_Value = models.FloatField()
-    
+
     def __str__(self):
         return "Generic"
 
@@ -140,7 +141,7 @@ class MagicItem(models.Model):
     Rarity = models.CharField(max_length=20)
     Effect_Description = models.CharField(max_length=255)
     Visual_Description = models.CharField(max_length=255)
-    
+
     def __str__(self):
         return "Magic"
 

--- a/toolkit/models.py
+++ b/toolkit/models.py
@@ -69,6 +69,8 @@ class Armor(models.Model):
     Weight = models.IntegerField()
     Stealth = models.BooleanField()
 
+    def __str__(self):
+        return "Armor"
 
 class Weapon(models.Model):
     """
@@ -96,6 +98,9 @@ class Weapon(models.Model):
     Special_Characteristics = models.IntegerField()
     # store as a binary where Heavy Light TwoHanded Reach Versatile Finesse Throwable Ammunition Special
     # So heavy two handed with reach would be 101100000
+    
+    def __str__(self):
+        return "Weapon"
 
 
 class GenericItem(models.Model):
@@ -113,6 +118,9 @@ class GenericItem(models.Model):
     Name = models.CharField(primary_key=True, max_length=30)
     Description = models.CharField(max_length=255)
     Base_Value = models.FloatField()
+    
+    def __str__(self):
+        return "Generic"
 
 
 class MagicItem(models.Model):
@@ -132,6 +140,9 @@ class MagicItem(models.Model):
     Rarity = models.CharField(max_length=20)
     Effect_Description = models.CharField(max_length=255)
     Visual_Description = models.CharField(max_length=255)
+    
+    def __str__(self):
+        return "Magic"
 
 
 class GeneratedLoot(models.Model):

--- a/toolkit/templates/loot_generator.html
+++ b/toolkit/templates/loot_generator.html
@@ -70,18 +70,28 @@
                                 placeholder="Enter Average Player Level...">
                     </div>
             </div>
-            <div class="col-sm-6 px-md-4 p-4" style="background-color: #7D8B8C;">
-                <div class="row p-2" style="height: 100%;">
-                    <div class="col-sm-4">
-                        <button type="submit" name="generate_button" class="btn btn-primary">GENERATE</button>
-                    </div>
-                    <div class="col-sm-4">
-                        <button type="submit" name="save_button" class="btn btn-primary" disabled>SAVE</button>
-                    </div>
-                    <div class="col-sm-4">
-                        <button type="submit" name="clear_button" class="btn btn-primary" disabled>EXPORT</button>
-                    </div>
-                </div>
+            <div class="col-lg-6 px-md-4 p-4" style="background-color: #7D8B8C;">
+                <div class="btn-group" style="width:100%" role="group" aria-label="Generate-buttons">
+                    <button type="submit"
+                            class="btn btn-lg btn-success"
+                            name="generate_button"
+                            style="--bs-btn-padding-y: 1rem;">
+                      GENERATE
+                    </button>
+                    <button type="submit"
+                            class="btn btn-lg btn-primary"
+                            name="save_button"
+                            style="--bs-btn-padding-y: 1rem;"
+                            disabled>
+                      SAVE
+                    </button>
+                    <button type="submit"
+                            name="clear_button"
+                            class="btn btn-lg btn-secondary"
+                            style="--bs-btn-padding-y: 1rem;">
+                      CLEAR
+                    </button>
+                  </div>
             </div>
         </div>
         <div class="row">

--- a/toolkit/templates/loot_generator.html
+++ b/toolkit/templates/loot_generator.html
@@ -5,7 +5,7 @@
 {% block application_pane %}
 <form action {% url "loot_generator" %} method="post" class="form">
     {% csrf_token %}
-<div class="container-fluid p-4">
+<div class="container-fluid">
     <div>
         <div class="row">
             <div class="loot-header">
@@ -53,25 +53,21 @@
                     </select>
             </div>
             <div class="col-sm-3 px-md-4 p-2" style="background-color: #7D8B8C;">
-                    <div class="form-group">
-                        <label for="total_hoard_value_input">Total Hoard Value</label>
+                        <label for="total_hoard_value_input" class="form-label">Total Hoard Value</label>
                         <input type="number" class="form-control" 
                                 id="total_hoard_value_input" 
                                 name="total_hoard_value" 
                                 value="{% if data.total_hoard_value.value != 0.0 %}{{ data.total_hoard_value.value }}{% endif %}"
                                 placeholder="Enter Approximate Hoard Value...">
-                    </div>
-                    <div class="form-group">
-                        <label for="average_player_level_input">Average Player Level</label>
+                        <label for="average_player_level_input" class="form-label">Average Player Level</label>
                         <input type="number" class="form-control" 
                                 id="average_player_level_input" 
                                 name="average_player_level" 
                                 value="{% if data.average_player_level.value != 0.0 %}{{ data.average_player_level.value }}{% endif %}"
                                 placeholder="Enter Average Player Level...">
-                    </div>
             </div>
             <div class="col-lg-6 px-md-4 p-4" style="background-color: #7D8B8C;">
-                <div class="btn-group" style="width:100%" role="group" aria-label="Generate-buttons">
+                <div class="btn-group vertical-center" style="width:100%" role="group" aria-label="Generate-buttons">
                     <button type="submit"
                             class="btn btn-lg btn-success"
                             name="generate_button"

--- a/toolkit/templates/loot_generator.html
+++ b/toolkit/templates/loot_generator.html
@@ -104,10 +104,10 @@
                     <table class="table table-hover">
                         <thead style="position: sticky; top: 0;">
                         <tr>
-                            <th scope="col" >#</th>
-                            <th scope="col">Name</th>
-                            <th scope="col">Type</th>
-                            <th scope="col">Value</th>
+                            <th style="width: 10%" scope="col" >#</th>
+                            <th style="width: 30%" scope="col">Name</th>
+                            <th style="width: 30%" scope="col">Type</th>
+                            <th style="width: 30%" scope="col">Value</th>
                         </tr>
                         </thead>
                         <tbody>

--- a/toolkit/templates/loot_generator.html
+++ b/toolkit/templates/loot_generator.html
@@ -111,36 +111,16 @@
                         </tr>
                         </thead>
                         <tbody>
-                        {% for armor in armor_list %}
+                        {% for item in generated_list %}
                             <tr>
-                                <th scope="row">1</th>
-                                <td>{{ armor.Name }}</td>
-                                <td>Armor</td>
-                                <td>{{ armor.Base_Value }}
-                            </tr>
-                        {% endfor %}
-                        {% for weapon in weapons_list %}
-                            <tr>
-                                <th scope="row">1</th>
-                                <td>{{ weapon.Name }}</td>
-                                <td>Weapon</td>
-                                <td>{{ weapon.Base_Value }}
-                            </tr>
-                        {% endfor %}
-                        {% for generic in generic_list %}
-                            <tr>
-                                <th scope="row">1</th>
-                                <td>{{ generic.Name }}</td>
-                                <td>Generic</td>
-                                <td>{{ generic.Base_Value }}
-                            </tr>
-                        {% endfor %}
-                        {% for magic in magic_list %}
-                            <tr>
-                                <th scope="row">1</th>
-                                <td>{{ magic.Name }}</td>
-                                <td>Magic</td>
-                                <td>{{ magic.Rarity }}
+                                <th scope="row">{{forloop.counter}}</th>
+                                <td>{{ item.Name }}</td>
+                                <td>{{ item }}</td>
+                                {% if item|stringformat:"s" != "Magic" %} 
+                                    <td>{{ item.Base_Value }}</td>
+                                {% else %}
+                                    <td>{{ item.Rarity }}</td>
+                                {% endif %}
                             </tr>
                         {% endfor %}
                         </tbody>

--- a/toolkit/views/loot_generator/loot_generator.py
+++ b/toolkit/views/loot_generator/loot_generator.py
@@ -47,9 +47,7 @@ class LootGenerator(View):
 
     def post(self, request: HttpRequest):
         """POST method for create user page."""
-        print(request.POST)
         form = GenerateLootInputs.from_dict(request.POST)
-        print(form)
         self.context["data"] = form
         self.context["error"] = None
         if form.is_valid():
@@ -67,8 +65,8 @@ class LootGenerator(View):
                         input_loot_type=form.loot_type.value,
                     )
                     loot_object = generated.get("loot_object")
-                    self.context["total_value"] = loot_object.Total_Value
-                    self.context["money"] = loot_object.Money
+                    self.context["total_value"] = int(loot_object.Total_Value)
+                    self.context["money"] = int(loot_object.Money)
                     self.context["armor_list"] = generated.get("armor")
                     self.context["weapons_list"] = generated.get("weapons")
                     self.context["generic_list"] = generated.get("general0")

--- a/toolkit/views/loot_generator/loot_generator.py
+++ b/toolkit/views/loot_generator/loot_generator.py
@@ -67,14 +67,16 @@ class LootGenerator(View):
                     loot_object = generated.get("loot_object")
                     self.context["total_value"] = int(loot_object.Total_Value)
                     self.context["money"] = int(loot_object.Money)
-                    self.context["armor_list"] = generated.get("armor")
-                    self.context["weapons_list"] = generated.get("weapons")
-                    self.context["generic_list"] = generated.get("general0")
-                    self.context["magic_list"] = generated.get("magic")
+                    generated_list = generated.get("armor")
+                    generated_list.extend(generated.get("weapons"))
+                    generated_list.extend(generated.get("general0"))
+                    generated_list.extend(generated.get("magic"))
+                    self.context["generated_list"] = generated_list
                     return render(request, "loot_generator.html", self.context)
                 if request.POST.get("save_button") is not None:
                     return render(request, "loot_generator.html", self.context)
-                if request.POST.get("export_button") is not None:
+                if request.POST.get("clear_button") is not None:
+                    self.context["data"] = GenerateLootInputs()
                     return render(request, "loot_generator.html", self.context)
             except ValueError as e:
                 logger.warning(traceback.format_exc())


### PR DESCRIPTION
# Loot Generation Enhancements

This PR is to enhance the existing Loot Generation page in master. 

## Link to github card
#147 

# Changes

* Line-up input boxes and make buttons bigger
* Line numbers for items 
* Reduction in code in numerous places
* Added __str__ functions for loot models to be able to determine and display Type in loot generator webpage


You may also wish to include links to related pull requests, issues, or branches which may affect your changes.
