### PR TITLE
Schiltz3/nav bar changes

### DIFF
--- a/toolkit/static/custom.css
+++ b/toolkit/static/custom.css
@@ -67,7 +67,7 @@ h5 {
     font-size: 2vh;
 }
 
-.navbar-expand-lg {
+.navbar-expand-sm {
     background-color: #7D8B8C;
     padding-left: 5rem !important;
     padding-right: 2rem !important;
@@ -77,7 +77,7 @@ h5 {
     padding: 15px 15px;
 }
 
-.navbar-expand-lg .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus {
+.navbar-expand-sm .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus {
     background-color: #545e5f;
     color: white;
 }

--- a/toolkit/templates/elements/bar.html
+++ b/toolkit/templates/elements/bar.html
@@ -4,10 +4,20 @@ bar is a template which takes a list or iterator of BarItem objects and creates 
 Uses group variable returned from get method to display options for NavBar.
 
 {% endcomment %}
-<nav class="navbar navbar-expand-lg navbar-light p-0">
+<nav class="navbar navbar-expand-sm navbar-light p-0">
   <a class="navbar-brand" href="{% url "home_page" %}">DM's Toolkit</a>
-  <div class="navbar-collapse collapse w-100 order-1 order-md-0 dual-collapse2">
-    <ul class="navbar-nav me-auto">
+  <button class="navbar-toggler p-2"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="navbar-collapse collapse w-100 dual-collapse2"
+       id="navbarSupportedContent">
+    <ul class="navbar-nav">
       <li class="nav-item active">
         <a class="nav-link" href="{% url 'character_generator' %}">Characters</a>
       </li>
@@ -18,8 +28,6 @@ Uses group variable returned from get method to display options for NavBar.
         <a class="nav-link" href="{% url 'loot_generator' %}">Loot</a>
       </li>
     </ul>
-  </div>
-  <div class="navbar-collapse collapse w-100 order-3 dual-collapse2">
     <ul class="navbar-nav ms-auto">
       {% if group == "admin" %}
         <li class="nav-item">

--- a/toolkit/templates/elements/bar.html
+++ b/toolkit/templates/elements/bar.html
@@ -28,13 +28,28 @@ Uses group variable returned from get method to display options for NavBar.
       {% else %}
         {% if user.is_authenticated %}
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{user.username}}</a>
-            <ul class="dropdown-menu dropdown-menu-large dropdown-menu-end" aria-labelledby="navbarDropdown">
-              <li><a class="dropdown-item" href="{% url 'saved_characters' %}">My Characters</a></li>
-              <li><a class="dropdown-item" href="{% url 'saved_loot' %}">My Loot</a></li>
-              <li><a class="dropdown-item" href="{% url 'saved_encounters' %}">My Encounters</a></li>
-              <li><hr class="dropdown-divider"></li>
-              <li><a class="dropdown-item" href="{% url 'logout' %}">Logout</a></li>
+            <a class="nav-link dropdown-toggle"
+               id="navbarDropdown"
+               role="button"
+               data-bs-toggle="dropdown"
+               aria-expanded="false">{{ user.username }}</a>
+            <ul class="dropdown-menu dropdown-menu-large dropdown-menu-end"
+                aria-labelledby="navbarDropdown">
+              <li>
+                <a class="dropdown-item" href="{% url 'saved_characters' %}">My Characters</a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{% url 'saved_loot' %}">My Loot</a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{% url 'saved_encounters' %}">My Encounters</a>
+              </li>
+              <li>
+                <hr class="dropdown-divider"/>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{% url 'logout' %}">Logout</a>
+              </li>
             </ul>
           </li>
         {% else %}


### PR DESCRIPTION
# Descriptive title

Add a navbar-toggler button to small screens to show navbar items as dropdown

![image](https://user-images.githubusercontent.com/45466247/201225705-b9912c12-8703-41a5-8851-f96a70deb78f.png)
Desktop viewing

![image](https://user-images.githubusercontent.com/45466247/201225757-ab2a6f84-b5e7-4c55-b846-cd19da27e74b.png)
sm screen
![image](https://user-images.githubusercontent.com/45466247/201225767-98182265-ebc7-451e-ab35-20c85fb7d0e2.png)
sm screen dropdown

## Link to github card
closes #160

# Changes
* Add `navbar-toggler`  
* removed unnecessary classes and padding from rest of navbar