### PR TITLE
Swap from `+` to f-string

### DIFF
--- a/toolkit/models.py
+++ b/toolkit/models.py
@@ -43,7 +43,7 @@ class Character(models.Model):
     Charisma = models.IntegerField()
 
     def __str__(self):
-        return self.Name + " Level " + self.Level + " " + self.Class
+        return f"Name: {self.Name}, lvl: {self.Level}, Class: {self.Class}"
 
 
 class Armor(models.Model):


### PR DESCRIPTION
# Resolve Type error
Printing Characters threw a type error.
Switched to using f-strings as they are much better and faster than adding or even using the `.format()` function
![image](https://user-images.githubusercontent.com/45466247/201499752-0c9d3b52-59e3-4641-832b-d5ee16f031fc.png)

## Link to github card
closes #187 

# Changes
*  Replaced _str_ body with f-string