### PR TITLE
John t/167 make hoard value and player level optional

### DIFF
--- a/Tests/test_loot_generator.py
+++ b/Tests/test_loot_generator.py
@@ -92,6 +92,30 @@ class TestLootGenerator(TestCase):
             }
         )
         self.assertTrue(form.is_valid())
+        
+    def test_valid_form_total_hoard_value_empty(self):
+        """Tests to see if a user's input form is valid when given empty total hoard value."""
+        form = self.form.from_dict(
+            {
+                "generator_type": self.generator_type,
+                "loot_type": self.loot_type,
+                "total_hoard_value": "",
+                "average_player_level": self.average_player_level,
+            }
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_valid_form_player_level_empty(self):
+        """Tests to see if a user's input form is valid when given empty player level."""
+        form = self.form.from_dict(
+            {
+                "generator_type": self.generator_type,
+                "loot_type": self.loot_type,
+                "total_hoard_value": self.total_hoard_value,
+                "average_player_level": "",
+            }
+        )
+        self.assertTrue(form.is_valid())
 
     def test_invalid_form_generator_type(self):
         """Tests to see if a user's input form is valid when given bad generator_type."""
@@ -118,43 +142,19 @@ class TestLootGenerator(TestCase):
         self.assertFalse(form.is_valid())
 
     def test_invalid_form_total_hoard_value(self):
-        """Tests to see if a user's input form is valid when given zero total hoard value."""
+        """Tests to see if a user's input form is valid when given less than zero total hoard value."""
         form = self.form.from_dict(
             {
                 "generator_type": self.generator_type,
                 "loot_type": self.loot_type,
-                "total_hoard_value": 0,
+                "total_hoard_value": -1,
                 "average_player_level": self.average_player_level,
-            }
-        )
-        self.assertFalse(form.is_valid())
-
-    def test_invalid_form_total_hoard_value_empty(self):
-        """Tests to see if a user's input form is valid when given empty total hoard value."""
-        form = self.form.from_dict(
-            {
-                "generator_type": self.generator_type,
-                "loot_type": self.loot_type,
-                "total_hoard_value": "",
-                "average_player_level": self.average_player_level,
-            }
-        )
-        self.assertFalse(form.is_valid())
-
-    def test_invalid_form_player_level_empty(self):
-        """Tests to see if a user's input form is valid when given empty player level."""
-        form = self.form.from_dict(
-            {
-                "generator_type": self.generator_type,
-                "loot_type": self.loot_type,
-                "total_hoard_value": self.total_hoard_value,
-                "average_player_level": "",
             }
         )
         self.assertFalse(form.is_valid())
 
     def test_invalid_form_player_level_zero(self):
-        """Tests to see if a user's input form is valid when given zero player level."""
+        """Tests to see if a user's input form is valid when given zero or less player level."""
         form = self.form.from_dict(
             {
                 "generator_type": self.generator_type,
@@ -211,8 +211,8 @@ class TestLootGenerator(TestCase):
         with self.assertRaises(KeyError):
             self.assertEqual(response.context["total_value"], 0)
 
-    def test_unsuccessful_generate_total_hoard_value(self):
-        """Tests if a user is able to successfully generate loot after giving incorrect hoard value input."""
+    def test_successful_generate_total_hoard_value(self):
+        """Tests if a user is able to successfully generate loot after giving empty hoard value input."""
         response = self.client.post(
             self.loot_generator_url,
             data={
@@ -225,11 +225,10 @@ class TestLootGenerator(TestCase):
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
-        with self.assertRaises(KeyError):
-            self.assertEqual(response.context["total_value"], 0)
+        self.assertNotEqual(response.context["total_value"], 0)
 
-    def test_unsuccessful_generate_average_player_level(self):
-        """Tests if a user is able to successfully generate loot after giving incorrect level input."""
+    def test_successful_generate_average_player_level(self):
+        """Tests if a user is able to successfully generate loot after giving empty level input."""
         response = self.client.post(
             self.loot_generator_url,
             data={
@@ -242,8 +241,23 @@ class TestLootGenerator(TestCase):
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
-        with self.assertRaises(KeyError):
-            self.assertEqual(response.context["total_value"], 0)
+        self.assertNotEqual(response.context["total_value"], 0)
+        
+    def test_successful_generate_average_player_level_hoard_value(self):
+        """Tests if a user is able to successfully generate loot after giving empty level input and hoard value."""
+        response = self.client.post(
+            self.loot_generator_url,
+            data={
+                "generate_button": "",
+                "generator_type": self.generator_type,
+                "loot_type": self.loot_type,
+                "total_hoard_value": "",
+                "average_player_level": "",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(response.context["total_value"], 0)
 
     def test_successful_generate(self):
         """Tests if a user is able to successfully generate loot after giving correct input."""

--- a/Tests/test_loot_generator.py
+++ b/Tests/test_loot_generator.py
@@ -92,7 +92,7 @@ class TestLootGenerator(TestCase):
             }
         )
         self.assertTrue(form.is_valid())
-        
+
     def test_valid_form_total_hoard_value_empty(self):
         """Tests to see if a user's input form is valid when given empty total hoard value."""
         form = self.form.from_dict(
@@ -242,7 +242,7 @@ class TestLootGenerator(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.context["total_value"], 0)
-        
+
     def test_successful_generate_average_player_level_hoard_value(self):
         """Tests if a user is able to successfully generate loot after giving empty level input and hoard value."""
         response = self.client.post(

--- a/toolkit/models.py
+++ b/toolkit/models.py
@@ -73,7 +73,7 @@ class Armor(models.Model):
 
     @property
     def type(self):
-        return f"Armor"
+        return "Armor"
 
 
 class Weapon(models.Model):
@@ -108,7 +108,7 @@ class Weapon(models.Model):
 
     @property
     def type(self):
-        return f"Weapon"
+        return "Weapon"
 
 
 class GenericItem(models.Model):
@@ -133,7 +133,7 @@ class GenericItem(models.Model):
 
     @property
     def type(self):
-        return f"Generic Item"
+        return "Generic Item"
 
 
 class MagicItem(models.Model):
@@ -159,7 +159,7 @@ class MagicItem(models.Model):
 
     @property
     def type(self):
-        return f"Magic Item"
+        return "Magic Item"
 
 
 class GeneratedLoot(models.Model):

--- a/toolkit/models.py
+++ b/toolkit/models.py
@@ -70,7 +70,7 @@ class Armor(models.Model):
 
     def __str__(self):
         return self.Name
-    
+
     @property
     def type(self):
         return f"Armor"
@@ -105,7 +105,7 @@ class Weapon(models.Model):
 
     def __str__(self):
         return self.Name
-    
+
     @property
     def type(self):
         return f"Weapon"
@@ -130,7 +130,7 @@ class GenericItem(models.Model):
 
     def __str__(self):
         return self.Name
-    
+
     @property
     def type(self):
         return f"Generic Item"
@@ -156,7 +156,7 @@ class MagicItem(models.Model):
 
     def __str__(self):
         return self.Name
-    
+
     @property
     def type(self):
         return f"Magic Item"

--- a/toolkit/models.py
+++ b/toolkit/models.py
@@ -70,6 +70,10 @@ class Armor(models.Model):
 
     def __str__(self):
         return self.Name
+    
+    @property
+    def type(self):
+        return f"Armor"
 
 
 class Weapon(models.Model):
@@ -101,6 +105,10 @@ class Weapon(models.Model):
 
     def __str__(self):
         return self.Name
+    
+    @property
+    def type(self):
+        return f"Weapon"
 
 
 class GenericItem(models.Model):
@@ -122,6 +130,10 @@ class GenericItem(models.Model):
 
     def __str__(self):
         return self.Name
+    
+    @property
+    def type(self):
+        return f"Generic Item"
 
 
 class MagicItem(models.Model):
@@ -144,6 +156,10 @@ class MagicItem(models.Model):
 
     def __str__(self):
         return self.Name
+    
+    @property
+    def type(self):
+        return f"Magic Item"
 
 
 class GeneratedLoot(models.Model):

--- a/toolkit/templates/loot_generator.html
+++ b/toolkit/templates/loot_generator.html
@@ -115,8 +115,8 @@
                             <tr>
                                 <th scope="row">{{forloop.counter}}</th>
                                 <td>{{ item.Name }}</td>
-                                <td>{{ item }}</td>
-                                {% if item|stringformat:"s" != "Magic" %} 
+                                <td>{{ item.type }}</td>
+                                {% if item.type != "Magic Item" %} 
                                     <td>{{ item.Base_Value }}</td>
                                 {% else %}
                                     <td>{{ item.Rarity }}</td>

--- a/toolkit/templates/loot_generator.html
+++ b/toolkit/templates/loot_generator.html
@@ -57,13 +57,13 @@
                 <input type="number" class="form-control" 
                         id="total_hoard_value_input" 
                         name="total_hoard_value" 
-                        value="{% if data.total_hoard_value.value != 0.0 %}{{ data.total_hoard_value.value }}{% endif %}"
+                        value="{{ data.total_hoard_value.value }}"
                         placeholder="Enter Approximate Hoard Value...">
                 <label for="average_player_level_input" class="form-label">Average Player Level</label>
                 <input type="number" class="form-control" 
                         id="average_player_level_input" 
                         name="average_player_level" 
-                        value="{% if data.average_player_level.value != 0.0 %}{{ data.average_player_level.value }}{% endif %}"
+                        value="{{ data.average_player_level.value }}"
                         placeholder="Enter Average Player Level...">
             </div>
             <div class="col-lg-6 px-md-4 p-4" style="background-color: #7D8B8C;">

--- a/toolkit/views/loot_generator/loot_generator.py
+++ b/toolkit/views/loot_generator/loot_generator.py
@@ -62,8 +62,8 @@ class LootGenerator(View):
             try:
                 generated = self.generator.generate_loot(
                     generator_key=form.generator_type.value,
-                    level=int(form.average_player_level.value),
-                    approximate_total_value=int(form.total_hoard_value.value),
+                    level = 1 if form.average_player_level.value == "" else int(form.average_player_level.value),
+                    approximate_total_value = 0 if form.total_hoard_value.value == "" else int(form.total_hoard_value.value),
                     input_loot_type=form.loot_type.value,
                 )
                 loot_object = generated.get("loot_object")
@@ -91,8 +91,8 @@ class GenerateLootInputs:
 
     generator_type: Element = field(default_factory=lambda: Element("Random"))
     loot_type: Element = field(default_factory=lambda: Element("Random"))
-    total_hoard_value: Element = field(default_factory=lambda: Element(0))
-    average_player_level: Element = field(default_factory=lambda: Element(0))
+    total_hoard_value: Element = field(default_factory=Element) # Optional
+    average_player_level: Element = field(default_factory=Element) # Optional
 
     @classmethod
     def from_dict(cls, env: dict[str, Any]):
@@ -128,12 +128,8 @@ class GenerateLootInputs:
             and self.loot_type.value != "Random"
         ):
             return False
-        if self.total_hoard_value.value == "":
+        if self.total_hoard_value.value != "" and int(self.total_hoard_value.value) < 0:
             return False
-        if int(self.total_hoard_value.value) <= 0:
-            return False
-        if self.average_player_level.value == "":
-            return False
-        if not 0 < int(self.average_player_level.value) <= 21:
+        if self.average_player_level.value != "" and not 0 < int(self.average_player_level.value) <= 21:
             return False
         return True

--- a/toolkit/views/loot_generator/loot_generator.py
+++ b/toolkit/views/loot_generator/loot_generator.py
@@ -62,8 +62,12 @@ class LootGenerator(View):
             try:
                 generated = self.generator.generate_loot(
                     generator_key=form.generator_type.value,
-                    level = 1 if form.average_player_level.value == "" else int(form.average_player_level.value),
-                    approximate_total_value = 0 if form.total_hoard_value.value == "" else int(form.total_hoard_value.value),
+                    level=1
+                    if form.average_player_level.value == ""
+                    else int(form.average_player_level.value),
+                    approximate_total_value=0
+                    if form.total_hoard_value.value == ""
+                    else int(form.total_hoard_value.value),
                     input_loot_type=form.loot_type.value,
                 )
                 loot_object = generated.get("loot_object")
@@ -91,8 +95,8 @@ class GenerateLootInputs:
 
     generator_type: Element = field(default_factory=lambda: Element("Random"))
     loot_type: Element = field(default_factory=lambda: Element("Random"))
-    total_hoard_value: Element = field(default_factory=Element) # Optional
-    average_player_level: Element = field(default_factory=Element) # Optional
+    total_hoard_value: Element = field(default_factory=Element)  # Optional
+    average_player_level: Element = field(default_factory=Element)  # Optional
 
     @classmethod
     def from_dict(cls, env: dict[str, Any]):
@@ -130,6 +134,9 @@ class GenerateLootInputs:
             return False
         if self.total_hoard_value.value != "" and int(self.total_hoard_value.value) < 0:
             return False
-        if self.average_player_level.value != "" and not 0 < int(self.average_player_level.value) <= 21:
+        if (
+            self.average_player_level.value != ""
+            and not 0 < int(self.average_player_level.value) <= 21
+        ):
             return False
         return True


### PR DESCRIPTION
# Hoard Value and Player Level Optional

Hoard value and player level inputs for loot generator are now optional as intended. Also, added property decorator function to loot models since recent PR #190 that was merged made Name and Type column in loot generator say the same thing as well as not display Rarity for magic items. Changes to tests as necessary

## Link to github card
closes #167 

# Changes
* Changes to loot tests
* Slight changes to loot template
* Changes to loot view to reflect hoard value and player level as optional fields
* Addition of "type" function in loot models to display in Type column for loot generator table


You may also wish to include links to related pull requests, issues, or branches which may affect your changes.
