### PR TITLE
Update Loot Generator Acceptance Tests

### DIFF
--- a/Tests/test_loot_generator.py
+++ b/Tests/test_loot_generator.py
@@ -327,6 +327,7 @@ class TestLootGenerator(TestCase):
         self.assertIsNotNone(cache.loot)
         
     def test_save_not_logged_in(self):
+        """Tests to see if a user can save generated loot while not logged in"""
         response = self.client.post(
             self.loot_generator_url,
             data={

--- a/toolkit/views/loot_generator/loot_generator_view.py
+++ b/toolkit/views/loot_generator/loot_generator_view.py
@@ -104,16 +104,17 @@ class LootGenerator(View):
                 self.context["error"] = str(e)
                 return render(request, "loot_generator.html", self.context)
         if request.POST.get("save_button") is not None:
-            self.context["cached"] = True
             if request.user.is_authenticated:
                 save_cached_loot(request.user)
                 messages.success(request, "Loot saved successfully!")
+                self.context["cached"] = False
             else:
                 self.context["form"] = form
             return render(request, "loot_generator.html", self.context)
         if request.POST.get("clear_button") is not None:
             if request.user.is_authenticated:
                 delete_cached_loot(request.user)
+                self.context["cached"] = False
             self.context["data"] = GenerateLootInputs()
             return render(request, "loot_generator.html", self.context)
         return render(request, "loot_generator.html", self.context)


### PR DESCRIPTION
# Save and Clear Acceptance Tests

This PR covers the remaining functionality of the loot view that consists of saving generated loot to the user's cache, to the database, and then clearing the user's cache.

## Link to github card
#210 

# Changes
* Addition of new tests
* Minor changes to loot view setting cached to False after saving and clearing
* 


You may also wish to include links to related pull requests, issues, or branches which may affect your changes.
